### PR TITLE
Add UnitsNetSetup to hold global static state

### DIFF
--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -7,12 +7,7 @@ namespace UnitsNet
 {
     public partial class Quantity
     {
-        static Quantity()
-        {
-            Default = UnitsNetSetup.Default.QuantityInfoLookup;
-        }
-
-        private static QuantityInfoLookup Default { get; }
+        private static QuantityInfoLookup Default => UnitsNetSetup.Default.QuantityInfoLookup;
 
         /// <summary>
         /// All enum value names of <see cref="Infos"/>, such as "Length" and "Mass".

--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -9,13 +9,10 @@ namespace UnitsNet
     {
         static Quantity()
         {
-            Default = new QuantityInfoLookup();
+            Default = UnitsNetSetup.Default.QuantityInfoLookup;
         }
 
-        private static QuantityInfoLookup Default
-        {
-            get;
-        }
+        private static QuantityInfoLookup Default { get; }
 
         /// <summary>
         /// All enum value names of <see cref="Infos"/>, such as "Length" and "Mass".
@@ -39,7 +36,7 @@ namespace UnitsNet
             Default.TryGetUnitInfo(unitEnum, out unitInfo);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="unit"></param>
         /// <param name="unitInfo"></param>

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -27,7 +27,7 @@ namespace UnitsNet
         private readonly UnitParser _unitParser;
 
         [Obsolete("Use UnitsNetSetup.Default.Parser instead.")]
-        public static QuantityParser Default { get; } = UnitsNetSetup.Default.QuantityParser;
+        public static QuantityParser Default => UnitsNetSetup.Default.QuantityParser;
 
         public QuantityParser(UnitAbbreviationsCache? unitAbbreviationsCache)
         {

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -26,17 +26,13 @@ namespace UnitsNet
         private readonly UnitAbbreviationsCache _unitAbbreviationsCache;
         private readonly UnitParser _unitParser;
 
-        public static QuantityParser Default { get; }
+        [Obsolete("Use UnitsNetSetup.Default.Parser instead.")]
+        public static QuantityParser Default { get; } = UnitsNetSetup.Default.QuantityParser;
 
         public QuantityParser(UnitAbbreviationsCache? unitAbbreviationsCache)
         {
             _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
             _unitParser = new UnitParser(_unitAbbreviationsCache);
-        }
-
-        static QuantityParser()
-        {
-            Default = new QuantityParser(UnitAbbreviationsCache.Default);
         }
 
         [SuppressMessage("ReSharper", "UseStringInterpolation")]

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -30,22 +30,48 @@ namespace UnitsNet
         /// <summary>
         ///     The static instance used internally for ToString() and Parse() of quantities and units.
         /// </summary>
-        public static UnitAbbreviationsCache Default { get; }
+        [Obsolete("Use UnitsNetSetup.Default.UnitAbbreviations instead.")]
+        public static UnitAbbreviationsCache Default { get; } = UnitsNetSetup.Default.UnitAbbreviations;
 
         private QuantityInfoLookup QuantityInfoLookup { get; }
 
         /// <summary>
-        ///     Create an instance of the cache and load all the abbreviations defined in the library.
+        ///     Creates an empty instance of the cache.
         /// </summary>
+        /// <remarks>
+        ///     TODO Change this to create an empty cache in v6: https://github.com/angularsen/UnitsNet/issues/1200
+        /// </remarks>
+        [Obsolete("Use CreateDefault() instead to create an instance that loads the built-in units. The default ctor will change to create an empty cache in UnitsNet v6.")]
         public UnitAbbreviationsCache()
+            : this(new QuantityInfoLookup(Quantity.ByName.Values))
         {
-            QuantityInfoLookup= new QuantityInfoLookup();
         }
 
-        static UnitAbbreviationsCache()
+        /// <summary>
+        ///     Creates an instance of the cache and load all the abbreviations defined in the library.
+        /// </summary>
+        /// <remarks>
+        ///     Access type is <c>internal</c> until this class is matured and ready for external use.
+        /// </remarks>
+        internal UnitAbbreviationsCache(QuantityInfoLookup quantityInfoLookup)
         {
-            Default = new UnitAbbreviationsCache();
+            QuantityInfoLookup = quantityInfoLookup;
         }
+
+        /// <summary>
+        ///     Create an instance with empty cache.
+        /// </summary>
+        /// <remarks>
+        ///     TODO Workaround until v6 changes the default ctor to create an empty cache.
+        /// </remarks>
+        /// <returns></returns>
+        public static UnitAbbreviationsCache CreateEmpty() => new(new QuantityInfoLookup(new List<QuantityInfo>()));
+
+        /// <summary>
+        ///     Create an instance of the cache and load all the built-in unit abbreviations defined in the library.
+        /// </summary>
+        /// <returns></returns>
+        public static UnitAbbreviationsCache CreateDefault() => new(new QuantityInfoLookup(Quantity.ByName.Values));
 
         /// <summary>
         /// Adds one or more unit abbreviation for the given unit enum value.

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -31,7 +31,7 @@ namespace UnitsNet
         ///     The static instance used internally for ToString() and Parse() of quantities and units.
         /// </summary>
         [Obsolete("Use UnitsNetSetup.Default.UnitAbbreviations instead.")]
-        public static UnitAbbreviationsCache Default { get; } = UnitsNetSetup.Default.UnitAbbreviations;
+        public static UnitAbbreviationsCache Default => UnitsNetSetup.Default.UnitAbbreviations;
 
         private QuantityInfoLookup QuantityInfoLookup { get; }
 

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -36,11 +36,9 @@ namespace UnitsNet
         private QuantityInfoLookup QuantityInfoLookup { get; }
 
         /// <summary>
-        ///     Creates an empty instance of the cache.
+        ///     Create an instance of the cache and load all the abbreviations defined in the library.
         /// </summary>
-        /// <remarks>
-        ///     TODO Change this to create an empty cache in v6: https://github.com/angularsen/UnitsNet/issues/1200
-        /// </remarks>
+        // TODO Change this to create an empty cache in v6: https://github.com/angularsen/UnitsNet/issues/1200
         [Obsolete("Use CreateDefault() instead to create an instance that loads the built-in units. The default ctor will change to create an empty cache in UnitsNet v6.")]
         public UnitAbbreviationsCache()
             : this(new QuantityInfoLookup(Quantity.ByName.Values))
@@ -62,15 +60,16 @@ namespace UnitsNet
         ///     Create an instance with empty cache.
         /// </summary>
         /// <remarks>
-        ///     TODO Workaround until v6 changes the default ctor to create an empty cache.
+        ///     Workaround until v6 changes the default ctor to create an empty cache.<br/>
         /// </remarks>
-        /// <returns></returns>
+        /// <returns>Instance with empty cache.</returns>
+        // TODO Remove in v6: https://github.com/angularsen/UnitsNet/issues/1200
         public static UnitAbbreviationsCache CreateEmpty() => new(new QuantityInfoLookup(new List<QuantityInfo>()));
 
         /// <summary>
         ///     Create an instance of the cache and load all the built-in unit abbreviations defined in the library.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Instance with default abbreviations cache.</returns>
         public static UnitAbbreviationsCache CreateDefault() => new(new QuantityInfoLookup(Quantity.ByName.Values));
 
         /// <summary>

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -23,20 +23,19 @@ namespace UnitsNet
         ///     The default static instance used internally to parse quantities and units using the
         ///     default abbreviations cache for all units and abbreviations defined in the library.
         /// </summary>
-        public static UnitParser Default { get; }
+        [Obsolete("Use UnitsNetSetup.Default.UnitParser instead.")]
+        public static UnitParser Default { get; } = UnitsNetSetup.Default.UnitParser;
 
         /// <summary>
         ///     Create a parser using the given unit abbreviations cache.
         /// </summary>
         /// <param name="unitAbbreviationsCache"></param>
+        /// <remarks>
+        ///     TODO Change this to not fallback to built-in units abbreviations when given null, in v6: https://github.com/angularsen/UnitsNet/issues/1200
+        /// </remarks>
         public UnitParser(UnitAbbreviationsCache? unitAbbreviationsCache)
         {
             _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
-        }
-
-        static UnitParser()
-        {
-            Default = new UnitParser(UnitAbbreviationsCache.Default);
         }
 
         /// <summary>

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -30,9 +30,7 @@ namespace UnitsNet
         ///     Create a parser using the given unit abbreviations cache.
         /// </summary>
         /// <param name="unitAbbreviationsCache"></param>
-        /// <remarks>
-        ///     TODO Change this to not fallback to built-in units abbreviations when given null, in v6: https://github.com/angularsen/UnitsNet/issues/1200
-        /// </remarks>
+        // TODO Change this to not fallback to built-in units abbreviations when given null, in v6: https://github.com/angularsen/UnitsNet/issues/1200
         public UnitParser(UnitAbbreviationsCache? unitAbbreviationsCache)
         {
             _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -24,7 +24,7 @@ namespace UnitsNet
         ///     default abbreviations cache for all units and abbreviations defined in the library.
         /// </summary>
         [Obsolete("Use UnitsNetSetup.Default.UnitParser instead.")]
-        public static UnitParser Default { get; } = UnitsNetSetup.Default.UnitParser;
+        public static UnitParser Default => UnitsNetSetup.Default.UnitParser;
 
         /// <summary>
         ///     Create a parser using the given unit abbreviations cache.

--- a/UnitsNet/CustomCode/UnitsNetSetup.cs
+++ b/UnitsNet/CustomCode/UnitsNetSetup.cs
@@ -1,0 +1,82 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System.Collections.Generic;
+using UnitsNet.Units;
+
+namespace UnitsNet;
+
+/// <summary>
+///     UnitsNet setup of quantities, units, unit abbreviations and conversion functions.<br />
+///     <br />
+///     For normal use, <see cref="Default" /> is used and can be manipulated to add new units or change default unit
+///     abbreviations.<br />
+///     Alternatively, a setup instance may be provided for most static methods, such as
+///     <see cref="Quantity.Parse(System.Type,string)" /> and
+///     <see cref="QuantityFormatter.Format{TUnitType}(UnitsNet.IQuantity{TUnitType},string)" />.
+/// </summary>
+public sealed class UnitsNetSetup
+{
+    static UnitsNetSetup()
+    {
+        var unitConverter = UnitConverter.CreateDefault();
+        ICollection<QuantityInfo> quantityInfos = Quantity.ByName.Values;
+
+        Default = new UnitsNetSetup(quantityInfos, unitConverter);
+    }
+
+    /// <summary>
+    ///     Create a new UnitsNet setup with the given quantities, their units and unit conversion functions between units.
+    /// </summary>
+    /// <param name="quantityInfos">The quantities and their units to support for unit conversions, Parse() and ToString().</param>
+    /// <param name="unitConverter">The unit converter instance.</param>
+    public UnitsNetSetup(ICollection<QuantityInfo> quantityInfos, UnitConverter unitConverter)
+    {
+        var quantityInfoLookup = new QuantityInfoLookup(quantityInfos);
+        var unitAbbreviations = new UnitAbbreviationsCache(quantityInfoLookup);
+
+        UnitConverter = unitConverter;
+        UnitAbbreviations = unitAbbreviations;
+        UnitParser = new UnitParser(unitAbbreviations);
+        QuantityParser = new QuantityParser(unitAbbreviations);
+        QuantityInfoLookup = quantityInfoLookup;
+    }
+
+    /// <summary>
+    ///     The global default UnitsNet setup of quantities, units, unit abbreviations and conversion functions.
+    ///     This setup is used by default in static Parse and ToString methods of quantities unless a setup instance is
+    ///     provided.
+    /// </summary>
+    /// <remarks>
+    ///     Manipulating this instance, such as adding new units or changing default unit abbreviations, will affect most
+    ///     usages of UnitsNet in the
+    ///     current AppDomain since the typical use is via static members and not providing a setup instance.
+    /// </remarks>
+    public static UnitsNetSetup Default { get; }
+
+    /// <summary>
+    ///     Converts between units of a quantity, such as from meters to centimeters of a given length.
+    /// </summary>
+    public UnitConverter UnitConverter { get; }
+
+    /// <summary>
+    ///     Maps unit enums to unit abbreviation strings for one or more cultures, used by ToString() and Parse() methods of
+    ///     quantities.
+    /// </summary>
+    public UnitAbbreviationsCache UnitAbbreviations { get; }
+
+    /// <summary>
+    ///     Parses units from strings, such as <see cref="LengthUnit.Centimeter" /> from "cm".
+    /// </summary>
+    public UnitParser UnitParser { get; }
+
+    /// <summary>
+    ///     Parses quantities from strings, such as parsing <see cref="Mass" /> from "1.2 kg".
+    /// </summary>
+    internal QuantityParser QuantityParser { get; }
+
+    /// <summary>
+    ///     The quantities and units that are loaded.
+    /// </summary>
+    internal QuantityInfoLookup QuantityInfoLookup { get; }
+}

--- a/UnitsNet/CustomCode/UnitsNetSetup.cs
+++ b/UnitsNet/CustomCode/UnitsNetSetup.cs
@@ -78,5 +78,8 @@ public sealed class UnitsNetSetup
     /// <summary>
     ///     The quantities and units that are loaded.
     /// </summary>
+    /// <remarks>
+    ///     Access type is <c>internal</c> until this class is matured and ready for external use.
+    /// </remarks>
     internal QuantityInfoLookup QuantityInfoLookup { get; }
 }

--- a/UnitsNet/QuantityInfoLookup.cs
+++ b/UnitsNet/QuantityInfoLookup.cs
@@ -9,24 +9,27 @@ namespace UnitsNet
     /// <summary>
     /// A collection of <see cref="QuantityInfo"/>.
     /// </summary>
-    public class QuantityInfoLookup
+    /// <remarks>
+    ///     Access type is <c>internal</c> until this class is matured and ready for external use.
+    /// </remarks>
+    internal class QuantityInfoLookup
     {
-        private readonly Lazy<QuantityInfo[]> InfosLazy;
-        private readonly Lazy<Dictionary<(Type, string), UnitInfo>> UnitTypeAndNameToUnitInfoLazy;
+        private readonly Lazy<QuantityInfo[]> _infosLazy;
+        private readonly Lazy<Dictionary<(Type, string), UnitInfo>> _unitTypeAndNameToUnitInfoLazy;
 
         /// <summary>
         /// New instance.
         /// </summary>
-        public QuantityInfoLookup()
+        /// <param name="quantityInfos"></param>
+        public QuantityInfoLookup(ICollection<QuantityInfo> quantityInfos)
         {
-            ICollection<QuantityInfo> quantityInfos = Quantity.ByName.Values;
             Names = quantityInfos.Select(qt => qt.Name).ToArray();
 
-            InfosLazy = new Lazy<QuantityInfo[]>(() => quantityInfos
+            _infosLazy = new Lazy<QuantityInfo[]>(() => quantityInfos
                 .OrderBy(quantityInfo => quantityInfo.Name)
                 .ToArray());
 
-            UnitTypeAndNameToUnitInfoLazy = new Lazy<Dictionary<(Type, string), UnitInfo>>(() =>
+            _unitTypeAndNameToUnitInfoLazy = new Lazy<Dictionary<(Type, string), UnitInfo>>(() =>
             {
                 return Infos
                     .SelectMany(quantityInfo => quantityInfo.UnitInfos
@@ -45,27 +48,27 @@ namespace UnitsNet
         /// <summary>
         /// All quantity information objects, such as <see cref="Length.Info"/> and <see cref="Mass.Info"/>.
         /// </summary>
-        public QuantityInfo[] Infos => InfosLazy.Value;
+        public QuantityInfo[] Infos => _infosLazy.Value;
 
         /// <summary>
         /// Get <see cref="UnitInfo"/> for a given unit enum value.
         /// </summary>
-        public UnitInfo GetUnitInfo(Enum unitEnum) => UnitTypeAndNameToUnitInfoLazy.Value[(unitEnum.GetType(), unitEnum.ToString())];
+        public UnitInfo GetUnitInfo(Enum unitEnum) => _unitTypeAndNameToUnitInfoLazy.Value[(unitEnum.GetType(), unitEnum.ToString())];
 
         /// <summary>
         /// Try to get <see cref="UnitInfo"/> for a given unit enum value.
         /// </summary>
         public bool TryGetUnitInfo(Enum unitEnum, [NotNullWhen(true)] out UnitInfo? unitInfo) =>
-            UnitTypeAndNameToUnitInfoLazy.Value.TryGetValue((unitEnum.GetType(), unitEnum.ToString()), out unitInfo);
+            _unitTypeAndNameToUnitInfoLazy.Value.TryGetValue((unitEnum.GetType(), unitEnum.ToString()), out unitInfo);
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="unit"></param>
         /// <param name="unitInfo"></param>
         public void AddUnitInfo(Enum unit, UnitInfo unitInfo)
         {
-            UnitTypeAndNameToUnitInfoLazy.Value.Add((unit.GetType(), unit.ToString()), unitInfo);
+            _unitTypeAndNameToUnitInfoLazy.Value.Add((unit.GetType(), unit.ToString()), unitInfo);
         }
 
         /// <summary>
@@ -77,6 +80,7 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">Unit value is not a know unit enum type.</exception>
         public IQuantity From(QuantityValue value, Enum unit)
         {
+            // TODO Support custom units, currently only hardcoded built-in quantities are supported.
             if (Quantity.TryFrom(value, unit, out IQuantity? quantity))
                 return quantity;
 
@@ -95,6 +99,7 @@ namespace UnitsNet
                 return false;
             }
 
+            // TODO Support custom units, currently only hardcoded built-in quantities are supported.
             return Quantity.TryFrom((QuantityValue)value, unit, out quantity);
         }
 
@@ -114,6 +119,7 @@ namespace UnitsNet
             if (!typeof(IQuantity).IsAssignableFrom(quantityType))
                 throw new ArgumentException($"Type {quantityType} must be of type UnitsNet.IQuantity.");
 
+            // TODO Support custom units, currently only hardcoded built-in quantities are supported.
             if (Quantity.TryParse(formatProvider, quantityType, quantityString, out IQuantity? quantity))
                 return quantity;
 
@@ -121,8 +127,11 @@ namespace UnitsNet
         }
 
         /// <inheritdoc cref="Quantity.TryParse(IFormatProvider,System.Type,string,out UnitsNet.IQuantity)"/>
-        public bool TryParse(Type quantityType, string quantityString, [NotNullWhen(true)] out IQuantity? quantity) =>
-            Quantity.TryParse(null, quantityType, quantityString, out quantity);
+        public bool TryParse(Type quantityType, string quantityString, [NotNullWhen(true)] out IQuantity? quantity)
+        {
+            // TODO Support custom units, currently only hardcoded built-in quantities are supported.
+            return Quantity.TryParse(null, quantityType, quantityString, out quantity);
+        }
 
         /// <summary>
         ///     Get a list of quantities that has the given base dimensions.
@@ -130,7 +139,7 @@ namespace UnitsNet
         /// <param name="baseDimensions">The base dimensions to match.</param>
         public IEnumerable<QuantityInfo> GetQuantitiesWithBaseDimensions(BaseDimensions baseDimensions)
         {
-            return InfosLazy.Value.Where(info => info.BaseDimensions.Equals(baseDimensions));
+            return _infosLazy.Value.Where(info => info.BaseDimensions.Equals(baseDimensions));
         }
     }
 }

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -39,7 +39,7 @@ namespace UnitsNet
         /// as adding your own third-party units and quantities to convert between.
         /// </summary>
         [Obsolete("Use UnitsNetSetup.Default.UnitConverter instead.")]
-        public static UnitConverter Default { get; } = UnitsNetSetup.Default.UnitConverter;
+        public static UnitConverter Default => UnitsNetSetup.Default.UnitConverter;
 
         /// <summary>
         /// Creates a new <see cref="UnitConverter"/> instance.

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -38,13 +38,8 @@ namespace UnitsNet
         /// The static instance used by Units.NET to convert between units. Modify this to add/remove conversion functions at runtime, such
         /// as adding your own third-party units and quantities to convert between.
         /// </summary>
-        public static UnitConverter Default { get; }
-
-        static UnitConverter()
-        {
-            Default = new UnitConverter();
-            RegisterDefaultConversions(Default);
-        }
+        [Obsolete("Use UnitsNetSetup.Default.UnitConverter instead.")]
+        public static UnitConverter Default { get; } = UnitsNetSetup.Default.UnitConverter;
 
         /// <summary>
         /// Creates a new <see cref="UnitConverter"/> instance.
@@ -61,6 +56,18 @@ namespace UnitsNet
         public UnitConverter(UnitConverter other)
         {
             ConversionFunctions = new ConcurrentDictionary<ConversionFunctionLookupKey, ConversionFunction>(other.ConversionFunctions);
+        }
+
+        /// <summary>
+        ///     Create an instance of the unit converter with all the built-in unit conversions defined in the library.
+        /// </summary>
+        /// <returns>The unit converter.</returns>
+        public static UnitConverter CreateDefault()
+        {
+            var unitConverter = new UnitConverter();
+            RegisterDefaultConversions(unitConverter);
+
+            return unitConverter;
         }
 
         private ConcurrentDictionary<ConversionFunctionLookupKey, ConversionFunction> ConversionFunctions


### PR DESCRIPTION
I built on your recent `QuantityInfoLookup` and added `UnitsNetSetup` to gather global state in a single place as a singleton, with the possibility of passing instances of it to static methods later to override the defaults.

This way, state is no longer scattered among multiple classes that depend on each other in non-obvious ways and where initialization order has caused issues up until now.

### Changes
- Add `UnitsNetSetup` to hold global state as a singleton property `Default` that controls default state initialization.
  - Add properties for all "services" that depend on global state: UnitConverter, UnitAbbreviationsCache, UnitParser, QuantityParser
- Forward all other `Default` singleton properties from these services to `UnitsNetSetup.Default` and mark obsolete
- Add some TODOs where it seems functionality is missing